### PR TITLE
be more explicit about types in find_mean_edit_distance function 

### DIFF
--- a/src/compute_attributes/mod.rs
+++ b/src/compute_attributes/mod.rs
@@ -206,8 +206,8 @@ pub fn find_shortest_edit_distance(list: &[String]) -> usize {
 
 /// Calculate the mean edit distance between all pairs of words on the list.
 pub fn find_mean_edit_distance(list: &[String]) -> f64 {
-    let mut sum_of_all_edit_distances = 0;
-    let mut number_of_edit_distances_measured = 0;
+    let mut sum_of_all_edit_distances: f64 = 0.0;
+    let mut number_of_edit_distances_measured: f64 = 0.0;
     for (i, word1) in list.iter().enumerate() {
         // The list[0..i] upper-bound in this inner loop is so that we don't do
         // twice as many calls as necessary. Otherwise we would be finding the
@@ -216,11 +216,11 @@ pub fn find_mean_edit_distance(list: &[String]) -> f64 {
         // distance to itself (0).
         for word2 in list[0..i].iter() {
             let this_edit_distance = find_edit_distance(word1, word2);
-            number_of_edit_distances_measured += 1;
-            sum_of_all_edit_distances += this_edit_distance as usize;
+            number_of_edit_distances_measured += 1.0;
+            sum_of_all_edit_distances += this_edit_distance as f64;
         }
     }
-    (sum_of_all_edit_distances as f64) / (number_of_edit_distances_measured as f64)
+    sum_of_all_edit_distances / number_of_edit_distances_measured
 }
 
 /// Nested loops in this function get the `longest_shared_prefix`


### PR DESCRIPTION
Should help avoid a bug when calculating mean edit distance for long lists. 

See: https://github.com/sts10/tidy/pull/52 and https://github.com/sts10/tidy/issues/44 for more.